### PR TITLE
Add support for managed discord server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 CHANGELOG.md
+terraform-provider-discord

--- a/bin/build
+++ b/bin/build
@@ -4,5 +4,11 @@ set -euxo pipefail
 
 go build -o terraform-provider-discord
 
-mkdir -p ~/.terraform.d/plugins/
-cp terraform-provider-discord ~/.terraform.d/plugins/
+PROVIDER_NAME="discord"
+PROVIDER_VERSION="1.0.0"
+RPOVIDER_REPO="localhost/dev/$PROVIDER_NAME"
+OS_ARCH="$(go env GOHOSTOS)_$(go env GOHOSTARCH)"
+PROVIDER_PATH="$HOME/.terraform.d/plugins/$RPOVIDER_REPO/$PROVIDER_VERSION/$OS_ARCH/terraform-provider-discord"
+
+mkdir -p "$(dirname "$PROVIDER_PATH")"
+cp terraform-provider-discord "$PROVIDER_PATH"

--- a/bin/build
+++ b/bin/build
@@ -3,4 +3,6 @@
 set -euxo pipefail
 
 go build -o terraform-provider-discord
+
+mkdir -p ~/.terraform.d/plugins/
 cp terraform-provider-discord ~/.terraform.d/plugins/

--- a/discord/provider.go
+++ b/discord/provider.go
@@ -26,6 +26,7 @@ func Provider() *schema.Provider {
 
 		ResourcesMap: map[string]*schema.Resource{
 			"discord_server":             resourceDiscordServer(),
+			"discord_managed_server":     resourceDiscordManagedServer(),
 			"discord_category_channel":   resourceDiscordCategoryChannel(),
 			"discord_text_channel":       resourceDiscordTextChannel(),
 			"discord_voice_channel":      resourceDiscordVoiceChannel(),

--- a/discord/resource_discord_server.go
+++ b/discord/resource_discord_server.go
@@ -10,16 +10,8 @@ import (
 	"golang.org/x/net/context"
 )
 
-func serverSchema() map[string]*schema.Schema {
+func baseServerSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"server_id": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"name": {
-			Type:     schema.TypeString,
-			Required: true,
-		},
 		"region": {
 			Type:     schema.TypeString,
 			Optional: true,
@@ -111,6 +103,36 @@ func serverSchema() map[string]*schema.Schema {
 	}
 }
 
+func managedServerSchema() map[string]*schema.Schema {
+	res := baseServerSchema()
+
+	res["server_id"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Required: true,
+	}
+	res["name"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+	}
+
+	return res
+}
+
+func serverSchema() map[string]*schema.Schema {
+	res := baseServerSchema()
+
+	res["server_id"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Computed: true,
+	}
+	res["name"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Required: true,
+	}
+
+	return res
+}
+
 func resourceDiscordServer() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceServerCreate,
@@ -135,7 +157,7 @@ func resourceDiscordManagedServer() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: serverSchema(),
+		Schema: managedServerSchema(),
 	}
 }
 

--- a/discord/resource_discord_server.go
+++ b/discord/resource_discord_server.go
@@ -10,6 +10,107 @@ import (
 	"golang.org/x/net/context"
 )
 
+func serverSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"server_id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"region": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"verification_level": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			Default:  0,
+			ValidateFunc: func(val interface{}, key string) (warns []string, errors []error) {
+				v := val.(int)
+				if v > 4 || v < 0 {
+					errors = append(errors, fmt.Errorf("verification_level must be between 0 and 4 inclusive, got: %d", v))
+				}
+
+				return
+			},
+		},
+		"explicit_content_filter": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			Default:  0,
+			ValidateFunc: func(val interface{}, key string) (warns []string, errors []error) {
+				v := val.(int)
+				if v > 2 || v < 0 {
+					errors = append(errors, fmt.Errorf("explicit_content_filter must be between 0 and 2 inclusive, got: %d", v))
+				}
+
+				return
+			},
+		},
+		"default_message_notifications": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			Default:  0,
+			ValidateFunc: func(val interface{}, key string) (warns []string, errors []error) {
+				v := val.(int)
+				if v != 0 && v != 1 {
+					errors = append(errors, fmt.Errorf("default_message_notifications must be 0 or 1, got: %d", v))
+				}
+
+				return
+			},
+		},
+		"afk_channel_id": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"afk_timeout": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			Default:  300,
+			ValidateFunc: func(val interface{}, key string) (warns []string, errors []error) {
+				v := val.(int)
+				if v < 0 {
+					errors = append(errors, fmt.Errorf("afk_timeout must be greater than 0, got: %d", v))
+				}
+
+				return
+			},
+		},
+		"icon_url": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"icon_data_uri": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"icon_hash": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"splash_url": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"splash_data_uri": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"splash_hash": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"owner_id": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+	}
+}
+
 func resourceDiscordServer() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceServerCreate,
@@ -20,104 +121,21 @@ func resourceDiscordServer() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"server_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"region": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"verification_level": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  0,
-				ValidateFunc: func(val interface{}, key string) (warns []string, errors []error) {
-					v := val.(int)
-					if v > 4 || v < 0 {
-						errors = append(errors, fmt.Errorf("verification_level must be between 0 and 4 inclusive, got: %d", v))
-					}
+		Schema: serverSchema(),
+	}
+}
 
-					return
-				},
-			},
-			"explicit_content_filter": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  0,
-				ValidateFunc: func(val interface{}, key string) (warns []string, errors []error) {
-					v := val.(int)
-					if v > 2 || v < 0 {
-						errors = append(errors, fmt.Errorf("explicit_content_filter must be between 0 and 2 inclusive, got: %d", v))
-					}
-
-					return
-				},
-			},
-			"default_message_notifications": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  0,
-				ValidateFunc: func(val interface{}, key string) (warns []string, errors []error) {
-					v := val.(int)
-					if v != 0 && v != 1 {
-						errors = append(errors, fmt.Errorf("default_message_notifications must be 0 or 1, got: %d", v))
-					}
-
-					return
-				},
-			},
-			"afk_channel_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"afk_timeout": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  300,
-				ValidateFunc: func(val interface{}, key string) (warns []string, errors []error) {
-					v := val.(int)
-					if v < 0 {
-						errors = append(errors, fmt.Errorf("afk_timeout must be greater than 0, got: %d", v))
-					}
-
-					return
-				},
-			},
-			"icon_url": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"icon_data_uri": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"icon_hash": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"splash_url": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"splash_data_uri": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"splash_hash": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"owner_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
+func resourceDiscordManagedServer() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceServerManagedCreate,
+		ReadContext:   resourceServerRead,
+		UpdateContext: resourceServerUpdate,
+		DeleteContext: resourceServerManagedDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
 		},
+
+		Schema: serverSchema(),
 	}
 }
 
@@ -205,6 +223,23 @@ func resourceServerCreate(ctx context.Context, d *schema.ResourceData, m interfa
 	}
 	d.Set("icon_hash", server.Icon)
 	d.Set("splash_hash", server.Splash)
+
+	return diags
+}
+
+func resourceServerManagedCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	serverIdInterface, ok := d.GetOk("server_id")
+	if !ok {
+		return diag.Errorf("Error: server_id must be set")
+	}
+	serverId, ok := serverIdInterface.(string)
+	if !ok {
+		return diag.Errorf("Error: server_id must be a string")
+	}
+
+	d.SetId(serverId)
 
 	return diags
 }
@@ -336,6 +371,14 @@ func resourceServerDelete(ctx context.Context, d *schema.ResourceData, m interfa
 	if err := client.Guild(getId(d.Id())).Delete(); err != nil {
 		return diag.Errorf("Failed to delete server: %s", err)
 	}
+
+	return diags
+}
+
+func resourceServerManagedDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	// noop
 
 	return diags
 }

--- a/docs/resources/managed_server.md
+++ b/docs/resources/managed_server.md
@@ -1,0 +1,33 @@
+# Managed Discord Server Resource
+
+A resource to create a server
+
+## Example Usage
+
+```hcl-terraform
+resource discord_managed_server my_server {
+    server_id = "my-server-id"
+}
+```
+
+## Argument Reference
+
+* `server_id` (Required) The ID of the server to manage
+* `name` (Optional) Name of the server
+* `region` (Optional) Region of the server
+* `verification_level` (Optional) Verification Level of the server
+* `explicit_content_filter` (Optional) Explicit Content Filter level
+* `default_message_notifications` (Optional) Default Message Notification settings (0 = all messages, 1 = mentions)
+* `afk_channel_id` (Optional) Channel ID for moving AFK users to
+* `af_timeout` (Optional)  many seconds before moving an AFK user
+* `icon_url` (Optional) Remote URL for setting the icon of the server
+* `icon_data_uri` (Optional) Data URI of an image to set the icon
+* `splash_url` (Optional) Remote URL for setting the splash of the server
+* `splash_data_uri` (Optional) Data URI of an image to set the splash
+* `owner_id` (Optional) Owner ID of the server (Setting this will transfer ownership)
+* `system_channel_id` (Optional) Channel ID for system messages
+
+## Attribute Reference
+
+* `icon_hash` Hash of the icon
+* `splash_hash` Hash of the splash


### PR DESCRIPTION
This PR adds support for "managed" discord servers. It's pretty much the same as the usual servers, but the server is not actually created or deleted, instead a `server_id` is required as input at creation, and the deletion does nothing.