### PR TITLE
Fix typo in server data source doc

### DIFF
--- a/docs/data-sources/discord_server.md
+++ b/docs/data-sources/discord_server.md
@@ -1,4 +1,4 @@
-# Discord Role Data Source
+# Discord Server Data Source
 
 Fetches a server's information.
 


### PR DESCRIPTION
It looks like the role data source doc was copied and the heading wasn't updated.