### PR TITLE
Fix issue with ID calculation that makes it impossible to import

### DIFF
--- a/discord/util.go
+++ b/discord/util.go
@@ -1,6 +1,11 @@
 package discord
 
-import "hash/crc32"
+import (
+	"errors"
+	"fmt"
+	"hash/crc32"
+	"strings"
+)
 
 func Hashcode(s string) int {
 	v := int(crc32.ChecksumIEEE([]byte(s)))
@@ -12,6 +17,21 @@ func Hashcode(s string) int {
 	}
 	// v == MinInt
 	return 0
+}
+
+// Helper function for generating a two part ID
+func generateTwoPartId(one string, two string) string {
+	return fmt.Sprintf("%s:%s", one, two)
+}
+
+// helper function for parsing a two part ID
+func parseTwoPartId(id string) (string, string, error) {
+	parts := strings.Split(id, ":")
+	if len(parts) != 2 {
+		return "", "", errors.New(fmt.Sprintf("Unable to parse ID, length of returned value is different than 2, got %d", len(parts)))
+	}
+
+	return parts[0], parts[1], nil
 }
 
 func contains[T comparable](array []T, value T) bool {


### PR DESCRIPTION
Closes #76

This fixes an issue where the import function would never work with the `resource_discord_memry_roles` resource. The reason for this is mainly due to how the ID is generated.

When you import a resource, terraform essentially sets the `ID` of the resource, then runs the `Read` operation to populate the data. However, because a crc32 IEEE hash is not reversible past a certain number of bits, you can't read the two required attributes (`user_id` and `server_id`) out of the hash. Instead, the code attempted to read them from the state, which is not _set_ at this point because `Create` has never been run.

This change updates the ID specification of the resource to one that works with the Import Passthrough, by changing it to be `server_id:user_id`. It will attempt to parse those two attributes out of the ID and use those; however if it fails to parse them it will fall back to the state values to attempt to maintain backwards compatibility. Since changing the user or server ID would by necessity change what the resource is querying, those two attributes are now flagged as `ForceNew: true`.