### PR TITLE
Fix terraform channel import

### DIFF
--- a/discord/resource_discord_channel.go
+++ b/discord/resource_discord_channel.go
@@ -213,6 +213,7 @@ func resourceChannelRead(ctx context.Context, d *schema.ResourceData, m interfac
 		return diag.Errorf("Invalid channel type: %d", channel.Type)
 	}
 
+	d.Set("server_id", channel.GuildID.String())
 	d.Set("type", channelType)
 	d.Set("name", channel.Name)
 	d.Set("position", channel.Position)


### PR DESCRIPTION
I don't think I was managing to explain the issue very well, but with the help of @timofurrer this is the fix for #74 

Now when you `terraform import discord_x_channel.y z` then `server_id` is pulled into the state correctly.