### PR TITLE
Support importing channel permissions

### DIFF
--- a/discord/resource_discord_channel_permission.go
+++ b/discord/resource_discord_channel_permission.go
@@ -1,10 +1,10 @@
 package discord
 
 import (
-	"fmt"
-	"strconv"
+	"log"
 
 	"github.com/andersfylling/disgord"
+	"github.com/andersfylling/snowflake/v5"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -75,7 +75,7 @@ func resourceChannelPermissionCreate(ctx context.Context, d *schema.ResourceData
 	}); err != nil {
 		return diag.Errorf("Failed to update channel permissions %s: %s", channelId.String(), err.Error())
 	} else {
-		d.SetId(strconv.Itoa(Hashcode(fmt.Sprintf("%s:%s:%s", channelId, overwriteId, d.Get("type").(string)))))
+		d.SetId(generateThreePartId(channelId.String(), overwriteId.String(), d.Get("type").(string)))
 
 		return diags
 	}
@@ -85,15 +85,29 @@ func resourceChannelPermissionRead(ctx context.Context, d *schema.ResourceData, 
 	var diags diag.Diagnostics
 	client := m.(*Context).Client
 
-	channelId := getId(d.Get("channel_id").(string))
-	overwriteId := getId(d.Get("overwrite_id").(string))
+	var channelId, overwriteId snowflake.Snowflake
+	var permissionType uint
+
+	cId, oId, pt, err := parseThreeIds(d.Id())
+	if err != nil {
+		log.Default().Printf("Unable to parse IDs out of the resource ID. Falling back on legacy config behavior.")
+		channelId = getId(d.Get("channel_id").(string))
+		overwriteId = getId(d.Get("overwrite_id").(string))
+		permissionType, _ = getDiscordChannelPermissionType(d.Get("type").(string))
+	} else {
+		channelId = getId(cId)
+		overwriteId = getId(oId)
+		permissionType, _ = getDiscordChannelPermissionType(pt)
+
+		d.Set("channel_id", channelId.String())
+		d.Set("overwrite_id", overwriteId.String())
+		d.Set("type", pt)
+	}
 
 	channel, err := client.Channel(channelId).Get()
 	if err != nil {
-		return diag.Errorf("Failed to find channel %s: %s", channelId.String(), err.Error())
+		return diag.Errorf("!!!NEW Failed to find channel %s: %s", channelId.String(), err.Error())
 	}
-
-	permissionType, _ := getDiscordChannelPermissionType(d.Get("type").(string))
 
 	for _, x := range channel.PermissionOverwrites {
 		if uint(x.Type) == uint(permissionType) && x.ID == overwriteId {

--- a/discord/util_general.go
+++ b/discord/util_general.go
@@ -22,6 +22,21 @@ func generateTwoPartId(one string, two string) string {
 	return fmt.Sprintf("%s:%s", one, two)
 }
 
+func parseThreeIds(id string) (string, string, string, error) {
+	parts := strings.SplitN(id, ":", 3)
+
+	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return "", "", "", fmt.Errorf("unexpected format of ID (%s), expected attribute1:attribute2:attriburte3", id)
+	}
+
+	return parts[0], parts[1], parts[2], nil
+}
+
+// Helper function for generating a two part ID
+func generateThreePartId(one string, two string, three string) string {
+	return fmt.Sprintf("%s:%s:%s", one, two, three)
+}
+
 func getId(v string) disgord.Snowflake {
 	return disgord.ParseSnowflakeString(v)
 }


### PR DESCRIPTION
This is a similar change to https://github.com/Lucky3028/terraform-provider-discord/pull/78 -- previously, a non-reversible hash was being used to generate IDs for channel permissions. This switches to using a three-part ID that can be imported explicitly.