### PR TITLE
Add readonly roles attribute to server

### DIFF
--- a/discord/data_source_discord_server.go
+++ b/discord/data_source_discord_server.go
@@ -75,6 +75,55 @@ func dataSourceDiscordServer() *schema.Resource {
 				Computed:    true,
 				Description: "The ID of the owner.",
 			},
+			"roles": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "List of roles in the server.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of the role.",
+						},
+						"permissions": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The permission bits of the role.",
+						},
+						"color": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Integer representation of the role color with decimal color code.",
+						},
+						"hoist": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "If the role is hoisted.",
+						},
+						"mentionable": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "If the role is mentionable.",
+						},
+						"position": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Position of the role. This is reverse indexed, with `@everyone` being `0`.",
+						},
+						"managed": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "If role is managed by another service.",
+						},
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of the role.",
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -129,6 +178,21 @@ func dataSourceDiscordServerRead(ctx context.Context, d *schema.ResourceData, m 
 	if server.OwnerID != "" {
 		d.Set("owner_id", server.OwnerID)
 	}
+
+	var roleMap []map[string]interface{}
+	for _, role := range server.Roles {
+		roleMap = append(roleMap, map[string]interface{}{
+			"name":        role.Name,
+			"permissions": role.Permissions,
+			"color":       role.Color,
+			"hoist":       role.Hoist,
+			"mentionable": role.Mentionable,
+			"position":    role.Position,
+			"managed":     role.Managed,
+			"id":          role.ID,
+		})
+	}
+	d.Set("roles", roleMap)
 
 	return diags
 }

--- a/discord/data_source_discord_server_test.go
+++ b/discord/data_source_discord_server_test.go
@@ -29,6 +29,7 @@ func TestAccDatasourceDiscordServer(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "explicit_content_filter", "2"),
 					resource.TestCheckResourceAttr(name, "afk_timeout", "300"),
 					resource.TestCheckResourceAttrSet(name, "owner_id"),
+					resource.TestCheckResourceAttrSet(name, "roles"),
 				),
 			},
 		},

--- a/discord/resource_discord_channel.go
+++ b/discord/resource_discord_channel.go
@@ -295,7 +295,7 @@ func resourceChannelUpdate(ctx context.Context, d *schema.ResourceData, m interf
 	)
 
 	name = map[bool]string{true: d.Get("name").(string), false: channel.Name}[d.HasChange("name")]
-	position = map[bool]int{true: int(d.Get("position").(int)), false: int(channel.Position)}[d.HasChange("position")]
+	position = map[bool]int{true: d.Get("position").(int), false: channel.Position}[d.HasChange("position")]
 
 	switch channelType {
 	case "text", "news":
@@ -305,8 +305,8 @@ func resourceChannelUpdate(ctx context.Context, d *schema.ResourceData, m interf
 		}
 	case "voice":
 		{
-			bitRate = map[bool]int{true: int(d.Get("bitrate").(int)), false: channel.Bitrate}[d.HasChange("bitrate")]
-			userLimit = map[bool]int{true: int(d.Get("user_limit").(int)), false: channel.UserLimit}[d.HasChange("user_limit")]
+			bitRate = map[bool]int{true: d.Get("bitrate").(int), false: channel.Bitrate}[d.HasChange("bitrate")]
+			userLimit = map[bool]int{true: d.Get("user_limit").(int), false: channel.UserLimit}[d.HasChange("user_limit")]
 		}
 	}
 

--- a/discord/resource_discord_role.go
+++ b/discord/resource_discord_role.go
@@ -1,11 +1,11 @@
 package discord
 
 import (
+	"context"
 	"github.com/bwmarrin/discordgo"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"golang.org/x/net/context"
 )
 
 func resourceDiscordRole() *schema.Resource {

--- a/discord/resource_discord_server_test.go
+++ b/discord/resource_discord_server_test.go
@@ -22,6 +22,8 @@ func TestAccResourceDiscordServer(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "explicit_content_filter", "0"),
 					resource.TestCheckResourceAttr(name, "afk_timeout", "300"),
 					resource.TestCheckResourceAttrSet(name, "owner_id"),
+					resource.TestCheckResourceAttr(name, "roles.#", "1"),
+					resource.TestCheckResourceAttrSet(name, "roles.0.id"),
 				),
 			},
 		},

--- a/docs/data-sources/server.md
+++ b/docs/data-sources/server.md
@@ -40,5 +40,22 @@ output "discord_api_region" {
 - `id` (String) The ID of the server.
 - `owner_id` (String) The ID of the owner.
 - `region` (String) The region of the server.
+- `roles` (List of Object) List of roles in the server. (see [below for nested schema](#nestedatt--roles))
 - `splash_hash` (String) The hash of the server splash.
 - `verification_level` (Number) The required verification level of the server.
+
+<a id="nestedatt--roles"></a>
+### Nested Schema for `roles`
+
+Read-Only:
+
+- `color` (Number)
+- `hoist` (Boolean)
+- `id` (String)
+- `managed` (Boolean)
+- `mentionable` (Boolean)
+- `name` (String)
+- `permissions` (Number)
+- `position` (Number)
+
+

--- a/docs/data-sources/server.md
+++ b/docs/data-sources/server.md
@@ -57,5 +57,3 @@ Read-Only:
 - `name` (String)
 - `permissions` (Number)
 - `position` (Number)
-
-

--- a/docs/resources/managed_server.md
+++ b/docs/resources/managed_server.md
@@ -44,7 +44,22 @@ resource "discord_managed_server" "my_server" {
 
 - `icon_hash` (String) Hash of the icon.
 - `id` (String) The ID of the server.
+- `roles` (List of Object) List of roles in the server. (see [below for nested schema](#nestedatt--roles))
 - `splash_hash` (String) Hash of the splash.
+
+<a id="nestedatt--roles"></a>
+### Nested Schema for `roles`
+
+Read-Only:
+
+- `color` (Number)
+- `hoist` (Boolean)
+- `id` (String)
+- `managed` (Boolean)
+- `mentionable` (Boolean)
+- `name` (String)
+- `permissions` (Number)
+- `position` (Number)
 
 ## Import
 

--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -44,8 +44,23 @@ resource "discord_server" "my_server" {
 
 - `icon_hash` (String) Hash of the icon.
 - `id` (String) The ID of the server.
+- `roles` (List of Object) List of roles in the server. (see [below for nested schema](#nestedatt--roles))
 - `server_id` (String) The ID of the server to manage.
 - `splash_hash` (String) Hash of the splash.
+
+<a id="nestedatt--roles"></a>
+### Nested Schema for `roles`
+
+Read-Only:
+
+- `color` (Number)
+- `hoist` (Boolean)
+- `id` (String)
+- `managed` (Boolean)
+- `mentionable` (Boolean)
+- `name` (String)
+- `permissions` (Number)
+- `position` (Number)
 
 ## Import
 


### PR DESCRIPTION
Adds a new attribute of `roles` to server resource and managed server. Allows to get all roles from a server.