### PR TITLE
Mark guild Role position as computed

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
+version: 2
 before:
   hooks:
     # this is just an example and not a requirement for provider building/publishing

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,5 @@
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
-version: 2
 before:
   hooks:
     # this is just an example and not a requirement for provider building/publishing

--- a/discord/resource_discord_role.go
+++ b/discord/resource_discord_role.go
@@ -62,10 +62,10 @@ func resourceDiscordRole() *schema.Resource {
 			"position": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				Default:      1,
+				Computed:     true,
 				ForceNew:     false,
 				ValidateFunc: validation.IntAtLeast(1),
-				Description:  "The position of the role. This is reverse indexed, with `@everyone` being `0`.",
+				Description:  "Position of the role. This is reverse indexed, with `@everyone` being `0`.",
 			},
 			"managed": {
 				Type:        schema.TypeBool,
@@ -132,6 +132,8 @@ func resourceRoleCreate(ctx context.Context, d *schema.ResourceData, m interface
 		} else {
 			d.Set("position", newPosition)
 		}
+	} else {
+		d.Set("position", role.Position)
 	}
 
 	d.SetId(role.ID)

--- a/discord/resource_discord_role.go
+++ b/discord/resource_discord_role.go
@@ -66,7 +66,7 @@ func resourceDiscordRole() *schema.Resource {
 				Computed:     true,
 				ForceNew:     false,
 				ValidateFunc: validation.IntAtLeast(1),
-				Description:  "Position of the role. This is reverse indexed, with `@everyone` being `0`.",
+				Description:  "The position of the role. This is reverse indexed, with `@everyone` being `0`.",
 			},
 			"managed": {
 				Type:        schema.TypeBool,

--- a/discord/resource_discord_role.go
+++ b/discord/resource_discord_role.go
@@ -31,20 +31,20 @@ func resourceDiscordRole() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    false,
-				Description: "The name of the role.",
+				Description: "Name of the role.",
 			},
 			"permissions": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Default:     0,
 				ForceNew:    false,
-				Description: "The permission bits of the role.",
+				Description: "Permission bits of the role.",
 			},
 			"color": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				ForceNew:    false,
-				Description: "The integer representation of the role color with decimal color code.",
+				Description: "Integer representation of the role color with decimal color code.",
 			},
 			"hoist": {
 				Type:        schema.TypeBool,
@@ -66,7 +66,7 @@ func resourceDiscordRole() *schema.Resource {
 				Computed:     true,
 				ForceNew:     false,
 				ValidateFunc: validation.IntAtLeast(1),
-				Description:  "The position of the role. This is reverse indexed, with `@everyone` being `0`.",
+				Description:  "Position of the role. This is reverse indexed, with `@everyone` being `0`.",
 			},
 			"managed": {
 				Type:        schema.TypeBool,
@@ -76,7 +76,7 @@ func resourceDiscordRole() *schema.Resource {
 			"id": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The ID of the role.",
+				Description: "ID of the role.",
 			},
 		},
 	}

--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -38,7 +38,7 @@ resource "discord_role" "moderator" {
 - `hoist` (Boolean) Whether the role should be hoisted. (default `false`)
 - `mentionable` (Boolean) Whether the role should be mentionable. (default `false`)
 - `permissions` (Number) The permission bits of the role.
-- `position` (Number) The position of the role. This is reverse indexed, with `@everyone` being `0`.
+- `position` (Number) Position of the role. This is reverse indexed, with `@everyone` being `0`.
 
 ### Read-Only
 

--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -29,20 +29,20 @@ resource "discord_role" "moderator" {
 
 ### Required
 
-- `name` (String) The name of the role.
+- `name` (String) Name of the role.
 - `server_id` (String) Which server the role will be in.
 
 ### Optional
 
-- `color` (Number) The integer representation of the role color with decimal color code.
+- `color` (Number) Integer representation of the role color with decimal color code.
 - `hoist` (Boolean) Whether the role should be hoisted. (default `false`)
 - `mentionable` (Boolean) Whether the role should be mentionable. (default `false`)
-- `permissions` (Number) The permission bits of the role.
-- `position` (Number) The position of the role. This is reverse indexed, with `@everyone` being `0`.
+- `permissions` (Number) Permission bits of the role.
+- `position` (Number) Position of the role. This is reverse indexed, with `@everyone` being `0`.
 
 ### Read-Only
 
-- `id` (String) The ID of the role.
+- `id` (String) ID of the role.
 - `managed` (Boolean) Whether this role is managed by another service.
 
 ## Import

--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -38,7 +38,7 @@ resource "discord_role" "moderator" {
 - `hoist` (Boolean) Whether the role should be hoisted. (default `false`)
 - `mentionable` (Boolean) Whether the role should be mentionable. (default `false`)
 - `permissions` (Number) The permission bits of the role.
-- `position` (Number) Position of the role. This is reverse indexed, with `@everyone` being `0`.
+- `position` (Number) The position of the role. This is reverse indexed, with `@everyone` being `0`.
 
 ### Read-Only
 


### PR DESCRIPTION
Mark the position of a role as computed. I find it is easier to create roles with terraform and then move them into position manually.

Currently, I have to use
```hcl
    lifecycle {
        ignore_changes = [position]
    }
```
and this would alleviate that.

Shouldn't be a breaking change but also might be worth releasing as a 2.0