### PR TITLE
feat: poll, external app, and voice channel status permissions

### DIFF
--- a/discord/data_source_discord_permission.go
+++ b/discord/data_source_discord_permission.go
@@ -62,6 +62,9 @@ func dataSourceDiscordPermission() *schema.Resource {
 		"create_events":               0x100000000000,
 		"use_external_sounds":         0x200000000000,
 		"send_voice_messages":         0x400000000000,
+		"set_voice_channel_status":    0x1000000000000,
+		"send_polls":                  0x2000000000000,
+		"use_external_apps":           0x4000000000000,
 	}
 
 	schemaMap := make(map[string]*schema.Schema)


### PR DESCRIPTION
adds send_polls and use_external_apps permissions

set_voice_channel_status isn't in the discord permission docs, but I verified it is in this position with a real discord server