### PR TITLE
Update Goreleaser config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ terraform.tfstate.backup
 .idea/
 
 .env
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
+version: 2
 before:
   hooks:
     # this is just an example and not a requirement for provider building/publishing

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,7 +35,8 @@ builds:
       goarch: '386'
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
-- format: zip
+- formats:
+    - zip
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'


### PR DESCRIPTION
# Changes

Resolves #159 

This PR upgrades the Goreleaser config to version 2, addresses a Goreleaser deprecation warning, and adds Goreleaser's build directory to the gitignore so it won't show as an untracked change when testing locally.

# Testing

Built locally with `goreleaser release --snapshot --clean`. Confirmed built successfully without warnings once I commented out the signing config as I don't have the keys to use that with. 