### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   goreleaser:
     name: Make a release on GitHub
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/Lucky3028/terraform-provider-discord/security/code-scanning/4](https://github.com/Lucky3028/terraform-provider-discord/security/code-scanning/4)

To fix this issue and follow GitHub’s best practices for least privilege, add a `permissions:` key to the `goreleaser` job with only the minimal permissions required for the steps it runs. The job pushes tags and creates releases, so it requires `contents: write` and probably `packages: write` for GoReleaser. If it interacts with pull requests, add `pull-requests: write`. At a minimum, start with `contents: write`, and add others only if necessary. This is to be placed under the job definition (before `runs-on:`), typically at line 12. No new imports or external libraries are needed, just a change to the YAML workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
