### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Lucky3028/terraform-provider-discord/security/code-scanning/3](https://github.com/Lucky3028/terraform-provider-discord/security/code-scanning/3)

To resolve the issue, you should add an explicit `permissions` block to the workflow. Since the workflow only checks out the source code and runs build/test steps, it does not need "write" access to `contents` or most other resources. The minimally required permission is `contents: read`, which allows the workflow to read the repository (necessary for `actions/checkout`). Add the following block near the top of the workflow, at the root level (before or after `on:`), so it applies to all jobs unless overridden. No additional methods or imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
