### PR TITLE
feat(server): add description attribute

### DIFF
--- a/discord/data_source_discord_server.go
+++ b/discord/data_source_discord_server.go
@@ -65,6 +65,11 @@ func dataSourceDiscordServer() *schema.Resource {
 				Computed:    true,
 				Description: "The hash of the server splash.",
 			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The description of the server.",
+			},
 			"afk_channel_id": {
 				Type:        schema.TypeInt,
 				Computed:    true,
@@ -168,6 +173,7 @@ func dataSourceDiscordServerRead(ctx context.Context, d *schema.ResourceData, m 
 	d.Set("afk_timeout", server.AfkTimeout)
 	d.Set("icon_hash", server.Icon)
 	d.Set("splash_hash", server.Splash)
+	d.Set("description", server.Description)
 	d.Set("default_message_notifications", int(server.DefaultMessageNotifications))
 	d.Set("verification_level", int(server.VerificationLevel))
 	d.Set("explicit_content_filter", int(server.ExplicitContentFilter))

--- a/discord/resource_discord_server.go
+++ b/discord/resource_discord_server.go
@@ -103,6 +103,11 @@ func baseServerSchema() map[string]*schema.Schema {
 			Computed:    true,
 			Description: "Hash of the splash.",
 		},
+		"description": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Description of the server.",
+		},
 		"owner_id": {
 			Type:        schema.TypeString,
 			Optional:    true,
@@ -273,6 +278,7 @@ func resourceServerCreate(ctx context.Context, d *schema.ResourceData, m interfa
 	server, err = client.GuildEdit(server.ID, &discordgo.GuildParams{
 		Icon:                        icon,
 		Region:                      d.Get("region").(string),
+		Description:                 d.Get("description").(string),
 		VerificationLevel:           &verificationLevel,
 		DefaultMessageNotifications: d.Get("default_message_notifications").(int),
 		ExplicitContentFilter:       d.Get("explicit_content_filter").(int),
@@ -361,6 +367,7 @@ func resourceServerRead(ctx context.Context, d *schema.ResourceData, m interface
 	d.Set("afk_timeout", server.AfkTimeout)
 	d.Set("icon_hash", server.Icon)
 	d.Set("splash_hash", server.Splash)
+	d.Set("description", server.Description)
 	d.Set("verification_level", server.VerificationLevel)
 	d.Set("default_message_notifications", server.DefaultMessageNotifications)
 	d.Set("explicit_content_filter", server.ExplicitContentFilter)
@@ -415,6 +422,10 @@ func resourceServerUpdate(ctx context.Context, d *schema.ResourceData, m interfa
 	}
 	if d.HasChange("splash_data_uri") {
 		guildParams.Splash = d.Get("splash_data_uri").(string)
+		edit = true
+	}
+	if d.HasChange("description") {
+		guildParams.Description = d.Get("description").(string)
 		edit = true
 	}
 	if d.HasChange("afk_channel_id") {

--- a/docs/data-sources/server.md
+++ b/docs/data-sources/server.md
@@ -35,6 +35,7 @@ output "discord_api_region" {
 - `afk_channel_id` (Number) The AFK channel ID.
 - `afk_timeout` (Number) The AFK timeout of the server.
 - `default_message_notifications` (Number) The default message notification level of the server.
+- `description` (String) The description of the server.
 - `explicit_content_filter` (Number) The explicit content filter level of the server.
 - `icon_hash` (String) The hash of the server icon.
 - `id` (String) The ID of the server.

--- a/docs/resources/managed_server.md
+++ b/docs/resources/managed_server.md
@@ -30,6 +30,7 @@ resource "discord_managed_server" "my_server" {
 - `afk_channel_id` (String) ID of the channel AFK users will be moved to.
 - `afk_timeout` (Number) How many seconds before moving an AFK user.
 - `default_message_notifications` (Number) Default message notification settings. (`0` = all messages, `1` = mentions)
+- `description` (String) Description of the server.
 - `explicit_content_filter` (Number) Explicit content filter level of the server.
 - `icon_data_uri` (String) Data URI of an image to set the server icon to. Overrides `icon_url`.
 - `icon_url` (String) Remote URL to set the icon of the server to.

--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -31,6 +31,7 @@ resource "discord_server" "my_server" {
 - `afk_channel_id` (String) ID of the channel AFK users will be moved to.
 - `afk_timeout` (Number) How many seconds before moving an AFK user.
 - `default_message_notifications` (Number) Default message notification settings. (`0` = all messages, `1` = mentions)
+- `description` (String) Description of the server.
 - `explicit_content_filter` (Number) Explicit content filter level of the server.
 - `icon_data_uri` (String) Data URI of an image to set the server icon to. Overrides `icon_url`.
 - `icon_url` (String) Remote URL to set the icon of the server to.


### PR DESCRIPTION
Add support for the guild `description` field in `discord_server`, `discord_managed_server` resources, and the `discord_server` data source.

The `description` field maps directly to the Discord API's [Modify Guild](https://discord.com/developers/docs/resources/guild#modify-guild) `description` parameter, which is already supported by discordgo's `GuildParams` struct.

### Changes
- Add `description` to `baseServerSchema` (optional string)
- Wire through create, read, and update functions
- Add to data source schema and read function
- Regenerate documentation