### PR TITLE
fix(server): prevent owner_id from being sent when unchanged

### DIFF
--- a/discord/resource_discord_server.go
+++ b/discord/resource_discord_server.go
@@ -464,19 +464,6 @@ func resourceServerUpdate(ctx context.Context, d *schema.ResourceData, m interfa
 		edit = true
 	}
 
-	ownerId, hasOwner := d.GetOk("owner_id")
-	if d.HasChange("owner_id") {
-		if hasOwner {
-			guildParams.OwnerID = ownerId.(string)
-			edit = true
-		}
-	} else {
-		if hasOwner {
-			guildParams.OwnerID = server.OwnerID
-			edit = true
-		}
-	}
-
 	if edit {
 		if _, err = client.GuildEdit(server.ID, guildParams, discordgo.WithContext(ctx)); err != nil {
 			return diag.Errorf("Failed to edit server: %s", err.Error())


### PR DESCRIPTION
Fixes #136.

## Problem

When updating any server attribute (name, description, etc.), the `owner_id` was always included in the API request — even when it hadn't changed. Discord returns `400 Bad Request` with "User is already owner" when you try to set the owner to the current owner.

## Cause

The update function had duplicate `owner_id` handling. The second block unconditionally set `guildParams.OwnerID = server.OwnerID` whenever `owner_id` was present in state, regardless of whether it changed. This forced an ownership transfer attempt on every edit.

## Fix

Removed the redundant block. The earlier `d.HasChange("owner_id")` check already handles ownership transfers correctly — `owner_id` is only included in the API call when it actually changes. This brings it in line with how every other field in the update function works.
