### PR TITLE
feat(message): add file attachment support to discord_message

### DIFF
--- a/discord/resource_discord_message.go
+++ b/discord/resource_discord_message.go
@@ -1,6 +1,10 @@
 package discord
 
 import (
+	"fmt"
+	"mime"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -39,10 +43,10 @@ func resourceDiscordMessage() *schema.Resource {
 				Description: "ID of the user who wrote the message.",
 			},
 			"content": {
-				AtLeastOneOf: []string{"content", "embed"},
+				AtLeastOneOf: []string{"content", "embed", "file"},
 				Type:         schema.TypeString,
 				Optional:     true,
-				Description:  "Text content of message. At least one of `content` or `embed` must be set.",
+				Description:  "Text content of message. At least one of `content`, `embed`, or `file` must be set.",
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					return old == strings.TrimSuffix(new, "\r\n")
 				},
@@ -65,11 +69,11 @@ func resourceDiscordMessage() *schema.Resource {
 				Description: "Whether this message triggers TTS. (default `false`)",
 			},
 			"embed": {
-				AtLeastOneOf: []string{"content", "embed"},
+				AtLeastOneOf: []string{"content", "embed", "file"},
 				Type:         schema.TypeList,
 				Optional:     true,
 				MaxItems:     1,
-				Description:  "An embed block. At least one of `content` or `embed` must be set.",
+				Description:  "An embed block. At least one of `content`, `embed`, or `file` must be set.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"title": {
@@ -285,6 +289,58 @@ func resourceDiscordMessage() *schema.Resource {
 				Default:     false,
 				Description: "Whether this message is pinned. (default `false`)",
 			},
+			"file": {
+				AtLeastOneOf: []string{"content", "embed", "file"},
+				Type:         schema.TypeList,
+				Optional:     true,
+				ForceNew:     true,
+				MaxItems:     10,
+				Description:  "A local file to attach to the message. Up to 10 file blocks are supported (Discord's per-message attachment limit). Any change to a `file` block recreates the message — Discord does not allow editing existing attachments in place.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"source": {
+							Type:        schema.TypeString,
+							Required:    true,
+							ForceNew:    true,
+							Description: "Path to a local file to upload as an attachment.",
+						},
+						"filename": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							ForceNew:    true,
+							Description: "Override the filename Discord stores for the attachment. Defaults to the basename of `source`.",
+						},
+						"content_type": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							ForceNew:    true,
+							Description: "MIME type to send with the upload. Auto-detected from the file extension when omitted.",
+						},
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "ID Discord assigned to the attachment.",
+						},
+						"url": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "CDN URL to the attachment.",
+						},
+						"proxy_url": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "URL to access the attachment via Discord's proxy.",
+						},
+						"size": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Size of the attachment in bytes (as reported by Discord).",
+						},
+					},
+				},
+			},
 			"type": {
 				Type:        schema.TypeInt,
 				Computed:    true,
@@ -313,9 +369,17 @@ func resourceMessageCreate(ctx context.Context, d *schema.ResourceData, m interf
 			embeds = append(embeds, embed)
 		}
 	}
+
+	files, closers, err := buildMessageFiles(d.Get("file").([]interface{}))
+	if err != nil {
+		return diag.Errorf("Failed to create message in %s: %s", channelId, err.Error())
+	}
+	defer closeAll(closers)
+
 	message, err := client.ChannelMessageSendComplex(channelId, &discordgo.MessageSend{
 		Content: d.Get("content").(string),
 		Embeds:  embeds,
+		Files:   files,
 		TTS:     d.Get("tts").(bool),
 	}, discordgo.WithContext(ctx))
 	if err != nil {
@@ -331,6 +395,7 @@ func resourceMessageCreate(ctx context.Context, d *schema.ResourceData, m interf
 	} else {
 		d.Set("embed", nil)
 	}
+	d.Set("file", flattenMessageAttachments(d.Get("file").([]interface{}), message.Attachments))
 	if message.GuildID != "" {
 		d.Set("server_id", message.GuildID)
 	}
@@ -369,6 +434,7 @@ func resourceMessageRead(ctx context.Context, d *schema.ResourceData, m interfac
 	if len(message.Embeds) > 0 {
 		d.Set("embed", unbuildEmbed(message.Embeds[0]))
 	}
+	d.Set("file", flattenMessageAttachments(d.Get("file").([]interface{}), message.Attachments))
 	if message.EditedTimestamp != nil {
 		d.Set("edited_timestamp", message.EditedTimestamp.Format(time.RFC3339))
 	}
@@ -442,4 +508,87 @@ func resourceMessageDelete(ctx context.Context, d *schema.ResourceData, m interf
 	} else {
 		return diags
 	}
+}
+
+// buildMessageFiles opens each configured `file` block for upload. The returned
+// closers must be closed by the caller after the request has been sent.
+func buildMessageFiles(blocks []interface{}) ([]*discordgo.File, []*os.File, error) {
+	if len(blocks) == 0 {
+		return nil, nil, nil
+	}
+	files := make([]*discordgo.File, 0, len(blocks))
+	closers := make([]*os.File, 0, len(blocks))
+	for i, raw := range blocks {
+		block, ok := raw.(map[string]interface{})
+		if !ok {
+			return nil, closers, fmt.Errorf("file block %d is not a map", i)
+		}
+		source, _ := block["source"].(string)
+		if source == "" {
+			return nil, closers, fmt.Errorf("file block %d has empty `source`", i)
+		}
+		fh, err := os.Open(source)
+		if err != nil {
+			return nil, closers, fmt.Errorf("failed to open %s: %w", source, err)
+		}
+		closers = append(closers, fh)
+
+		name, _ := block["filename"].(string)
+		if name == "" {
+			name = filepath.Base(source)
+		}
+		ctype, _ := block["content_type"].(string)
+		if ctype == "" {
+			ctype = mime.TypeByExtension(filepath.Ext(name))
+		}
+		files = append(files, &discordgo.File{
+			Name:        name,
+			ContentType: ctype,
+			Reader:      fh,
+		})
+	}
+	return files, closers, nil
+}
+
+func closeAll(files []*os.File) {
+	for _, f := range files {
+		_ = f.Close()
+	}
+}
+
+// flattenMessageAttachments merges Discord's response (`attachments`) into the
+// list the user configured. Order follows the original config so the per-index
+// `source`/`filename`/`content_type` inputs are preserved; computed fields
+// (`id`, `url`, `proxy_url`, `size`) come from the API response.
+func flattenMessageAttachments(blocks []interface{}, attachments []*discordgo.MessageAttachment) []interface{} {
+	if len(blocks) == 0 && len(attachments) == 0 {
+		return nil
+	}
+	out := make([]interface{}, 0, len(blocks))
+	for i, raw := range blocks {
+		block, _ := raw.(map[string]interface{})
+		if block == nil {
+			block = map[string]interface{}{}
+		}
+		merged := map[string]interface{}{
+			"source":       block["source"],
+			"filename":     block["filename"],
+			"content_type": block["content_type"],
+		}
+		if i < len(attachments) && attachments[i] != nil {
+			a := attachments[i]
+			merged["id"] = a.ID
+			merged["url"] = a.URL
+			merged["proxy_url"] = a.ProxyURL
+			merged["size"] = a.Size
+			if merged["filename"] == "" {
+				merged["filename"] = a.Filename
+			}
+			if merged["content_type"] == "" {
+				merged["content_type"] = a.ContentType
+			}
+		}
+		out = append(out, merged)
+	}
+	return out
 }

--- a/discord/resource_discord_message.go
+++ b/discord/resource_discord_message.go
@@ -294,8 +294,8 @@ func resourceDiscordMessage() *schema.Resource {
 				Type:         schema.TypeList,
 				Optional:     true,
 				ForceNew:     true,
-				MaxItems:     10,
-				Description:  "A local file to attach to the message. Up to 10 file blocks are supported (Discord's per-message attachment limit). Any change to a `file` block recreates the message — Discord does not allow editing existing attachments in place.",
+				MaxItems:     messageMaxAttachments,
+				Description:  fmt.Sprintf("A local file to attach to the message. Up to %d file blocks are supported (Discord's per-message attachment limit). Any change to a `file` block recreates the message — Discord does not allow editing existing attachments in place.", messageMaxAttachments),
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"source": {
@@ -510,11 +510,17 @@ func resourceMessageDelete(ctx context.Context, d *schema.ResourceData, m interf
 	}
 }
 
+// messageMaxAttachments is Discord's hard cap on file attachments per message.
+const messageMaxAttachments = 10
+
 // buildMessageFiles opens each configured `file` block for upload. The returned
 // closers must be closed by the caller after the request has been sent.
 func buildMessageFiles(blocks []interface{}) ([]*discordgo.File, []*os.File, error) {
 	if len(blocks) == 0 {
 		return nil, nil, nil
+	}
+	if len(blocks) > messageMaxAttachments {
+		return nil, nil, fmt.Errorf("a message may have at most %d file attachments, got %d", messageMaxAttachments, len(blocks))
 	}
 	files := make([]*discordgo.File, 0, len(blocks))
 	closers := make([]*os.File, 0, len(blocks))

--- a/discord/resource_discord_message_test.go
+++ b/discord/resource_discord_message_test.go
@@ -3,6 +3,7 @@ package discord
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -53,6 +54,62 @@ func TestAccResourceDiscordMessageEmbed(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccResourceDiscordMessageFile(t *testing.T) {
+	testChannelID := os.Getenv("DISCORD_TEST_CHANNEL_ID")
+	if testChannelID == "" {
+		t.Skip("DISCORD_TEST_CHANNEL_ID envvar must be set for acceptance tests")
+	}
+
+	dir := t.TempDir()
+	imagePath := filepath.Join(dir, "hello.png")
+	// Smallest valid 1x1 transparent PNG.
+	pngBytes := []byte{
+		0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+		0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+		0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+		0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+		0x89, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x44, 0x41,
+		0x54, 0x78, 0x9C, 0x62, 0x00, 0x01, 0x00, 0x00,
+		0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00,
+		0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE,
+		0x42, 0x60, 0x82,
+	}
+	if err := os.WriteFile(imagePath, pngBytes, 0o644); err != nil {
+		t.Fatalf("seed image: %v", err)
+	}
+
+	name := "discord_message.example"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceDiscordMessageFile(testChannelID, imagePath),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "channel_id", testChannelID),
+					resource.TestCheckResourceAttr(name, "content", "Hello from Terraform with attachment!"),
+					resource.TestCheckResourceAttr(name, "file.#", "1"),
+					resource.TestCheckResourceAttr(name, "file.0.filename", "hello.png"),
+					resource.TestCheckResourceAttrSet(name, "file.0.id"),
+					resource.TestCheckResourceAttrSet(name, "file.0.url"),
+					resource.TestCheckResourceAttrSet(name, "file.0.size"),
+				),
+			},
+		},
+	})
+}
+
+func testAccResourceDiscordMessageFile(channelID, imagePath string) string {
+	return fmt.Sprintf(`
+	resource "discord_message" "example" {
+      channel_id = "%[1]s"
+      content    = "Hello from Terraform with attachment!"
+      file {
+        source = "%[2]s"
+      }
+	}`, channelID, imagePath)
 }
 
 func testAccResourceDiscordMessageContent(channelID string) string {

--- a/docs/resources/message.md
+++ b/docs/resources/message.md
@@ -55,9 +55,10 @@ resource "discord_message" "hello_world" {
 
 ### Optional
 
-- `content` (String) Text content of message. At least one of `content` or `embed` must be set.
+- `content` (String) Text content of message. At least one of `content`, `embed`, or `file` must be set.
 - `edited_timestamp` (String) When the message was edited.
-- `embed` (Block List, Max: 1) An embed block. At least one of `content` or `embed` must be set. (see [below for nested schema](#nestedblock--embed))
+- `embed` (Block List, Max: 1) An embed block. At least one of `content`, `embed`, or `file` must be set. (see [below for nested schema](#nestedblock--embed))
+- `file` (Block List, Max: 10) A local file to attach to the message. Up to 10 file blocks are supported (Discord's per-message attachment limit). Any change to a `file` block recreates the message — Discord does not allow editing existing attachments in place. (see [below for nested schema](#nestedblock--file))
 - `pinned` (Boolean) Whether this message is pinned. (default `false`)
 - `tts` (Boolean) Whether this message triggers TTS. (default `false`)
 
@@ -181,6 +182,26 @@ Optional:
 - `height` (Number) Height of the video.
 - `width` (Number) Width of the video.
 
+
+
+<a id="nestedblock--file"></a>
+### Nested Schema for `file`
+
+Required:
+
+- `source` (String) Path to a local file to upload as an attachment.
+
+Optional:
+
+- `content_type` (String) MIME type to send with the upload. Auto-detected from the file extension when omitted.
+- `filename` (String) Override the filename Discord stores for the attachment. Defaults to the basename of `source`.
+
+Read-Only:
+
+- `id` (String) ID Discord assigned to the attachment.
+- `proxy_url` (String) URL to access the attachment via Discord's proxy.
+- `size` (Number) Size of the attachment in bytes (as reported by Discord).
+- `url` (String) CDN URL to the attachment.
 
 
 

--- a/examples/resources/discord_message/file.tf
+++ b/examples/resources/discord_message/file.tf
@@ -1,0 +1,22 @@
+resource "discord_message" "instructions_step_1" {
+  channel_id = var.channel_id
+  content    = "**Step 1.** Click the arrow next to the server name."
+
+  file {
+    source = "${path.module}/assets/step1.png"
+  }
+}
+
+resource "discord_message" "release_notes" {
+  channel_id = var.channel_id
+  content    = "New release! See the attached changelog and screenshot."
+
+  file {
+    source   = "${path.module}/assets/changelog.txt"
+    filename = "CHANGELOG-v1.2.0.txt"
+  }
+
+  file {
+    source = "${path.module}/assets/screenshot.png"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a `file` nested block to `discord_message` so local files can be uploaded as message attachments.
- Up to 10 file blocks per message (Discord's per-message attachment limit), with optional `filename` and `content_type` overrides; Discord-assigned `id`, `url`, `proxy_url`, and `size` are exposed as computed attributes.
- The block is `ForceNew` — Discord does not support editing existing attachments in place, so any change recreates the message. This keeps Terraform state and the server in sync.

## Why

Posting messages with image attachments currently can't be expressed in this provider, so users fall back to bash scripts that call the Discord API directly (e.g. multipart `files[0]=@image` uploads). This change closes that gap for the common case of static instructional messages with images.

Embed-with-`attachment://` is not a substitute: the embed renders the image inside a bordered box rather than inline, and either way still requires raw attachment support to get the local file into the request.

## Implementation notes

- Uses `discordgo.MessageSend.Files` (already typed in v0.29.0) — no raw `Session.Request` workaround needed.
- `buildMessageFiles` opens each file and returns closers that the caller defers; `flattenMessageAttachments` merges Discord's response (`id`, `url`, `proxy_url`, `size`, `filename`, `content_type`) back into the per-block state, preserving the user-configured order.
- `content` / `embed` / `file` now share a single `AtLeastOneOf` set so any one of them satisfies the constraint.
- Content-type is auto-detected via `mime.TypeByExtension(filepath.Ext(name))` when not explicitly set.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./discord/ -run TestProvider` passes (schema validates via `InternalValidate`)
- [x] `go generate ./...` regenerated `docs/resources/message.md` (included in diff)
- [ ] `TF_ACC=1 DISCORD_TOKEN=… DISCORD_TEST_CHANNEL_ID=… go test ./discord/ -run TestAccResourceDiscordMessageFile -v` (acceptance test included; needs to be run against a real test server before merge — see `discord/resource_discord_message_test.go`)

## Open questions

1. Should `file` also accept a base64 data URI (similar to `data.discord_local_image.data_uri`) as an alternative to a local path? Left out for now — local path covers 100% of the motivating use case.
2. `ForceNew` on the whole block is deliberate. An alternative is to model edits via Discord's "send list of attachment IDs to keep" API, but that's significantly more complex and rarely needed in practice. Happy to revisit if reviewers prefer the edit-in-place approach.