### PR TITLE
fix(channel): return sibling-relative position on Read

### DIFF
--- a/discord/resource_discord_channel.go
+++ b/discord/resource_discord_channel.go
@@ -235,7 +235,20 @@ func resourceChannelRead(ctx context.Context, d *schema.ResourceData, m interfac
 	d.Set("server_id", channel.GuildID)
 	d.Set("type", channelType)
 	d.Set("name", channel.Name)
-	d.Set("position", channel.Position)
+
+	// Discord stores positions as a guild-wide flat counter, but practitioners
+	// configure positions per-category (0-indexed within siblings). Translate
+	// here so state matches what users typically write in HCL.
+	if channelType == "category" {
+		// Categories are top-level; their position is meaningful guild-wide.
+		d.Set("position", channel.Position)
+	} else {
+		localPos, err := siblingPosition(ctx, client, channel)
+		if err != nil {
+			return diag.Errorf("Failed to compute sibling-relative position for %s: %s", channel.ID, err.Error())
+		}
+		d.Set("position", localPos)
+	}
 
 	switch channelType {
 	case "text", "news":

--- a/discord/util_channel.go
+++ b/discord/util_channel.go
@@ -2,9 +2,50 @@ package discord
 
 import (
 	"context"
+	"sort"
 
 	"github.com/bwmarrin/discordgo"
 )
+
+// siblingPosition returns the index of `channel` among its same-parent
+// siblings when sorted by Discord's stored position. Discord's
+// `Channel.position` is a guild-wide flat counter, while HCL typically
+// expresses positions relative to siblings within a category (0, 1, 2, ...).
+// Returning the sibling index keeps Terraform state in sync with how users
+// write channel positions.
+//
+// Categories themselves are sorted guild-wide and should not be passed here.
+func siblingPosition(ctx context.Context, client *discordgo.Session, channel *discordgo.Channel) (int, error) {
+	all, err := client.GuildChannels(channel.GuildID, discordgo.WithContext(ctx))
+	if err != nil {
+		return 0, err
+	}
+	siblings := make([]*discordgo.Channel, 0)
+	for _, c := range all {
+		if c.Type == discordgo.ChannelTypeGuildCategory {
+			continue
+		}
+		if c.ParentID != channel.ParentID {
+			continue
+		}
+		siblings = append(siblings, c)
+	}
+	sort.SliceStable(siblings, func(i, j int) bool {
+		if siblings[i].Position != siblings[j].Position {
+			return siblings[i].Position < siblings[j].Position
+		}
+		// Tie-break on ID for stable ordering when Discord stores equal positions.
+		return siblings[i].ID < siblings[j].ID
+	})
+	for i, c := range siblings {
+		if c.ID == channel.ID {
+			return i, nil
+		}
+	}
+	// Channel wasn't found among its declared siblings — fall back to the
+	// guild-wide value to avoid masking the inconsistency.
+	return channel.Position, nil
+}
 
 func getTextChannelType(channelType discordgo.ChannelType) (string, bool) {
 	switch channelType {


### PR DESCRIPTION
## Summary

`Channel.position` on `discord_text_channel`, `discord_voice_channel`, `discord_news_channel`, and `discord_forum_channel` is now reported as a sibling-relative index within the channel's parent category, instead of Discord's guild-wide flat counter. Categories themselves continue to use the guild-wide value because they are sorted at the top level.

## Why

Discord stores every non-category channel's `position` as a single guild-wide integer. Practitioners, however, almost always express positions relative to siblings inside a category — `position = 0` for the first channel, `position = 1` for the second, etc. (it's what arithmetic like `troop_index * 3 + 0` naturally produces).

The mismatch causes a permanent, never-resolving state drift:

1. HCL declares `position = 0` for the first channel in a category.
2. Discord stores that channel at guild-wide position `7` (or wherever the category falls in the global ordering).
3. `terraform plan` shows the drift as `position: 7 -> 0`.
4. `terraform apply` PATCHes with `position = 0 ` + `parent_id`. Discord re-normalises within the parent and returns to guild-wide `7` on the next Read.
5. Next plan: same drift. Repeat forever.

The behaviour is reproducible on any reasonably-sized guild (we hit it consistently on a server with ~80 channels split across several categories, producing 50-60 spurious changes on every plan).

## Fix

In `resourceChannelRead`, for any non-category channel:

1. Fetch the guild's channels via `client.GuildChannels`.
2. Filter to siblings with the same `parent_id` (excluding category channels — they're not in the same sort scope).
3. Sort by Discord's `position` (with `id` as a stable tiebreak).
4. Set `position` in state to this channel's index in that sorted list.

Categories keep the existing behaviour because their position is meaningful at the guild level.

The helper lives in `discord/util_channel.go` as `siblingPosition(...)`.

## Trade-off

This adds one extra `GuildChannels` API call per non-category channel Read. The cost matches the existing pattern in this resource: `arePermissionsSynced` already fetches the parent channel per Read. A future optimisation could cache the guild channel list on the provider `Context` if the extra calls become a problem on very large guilds.

## Behavioural impact

- **First plan after upgrade:** existing channels' state will refresh to small contiguous numbers matching their HCL declarations. There will be no destructive changes — only state values are rewritten.
- **No HCL changes required** for users — the field semantics now match what was already intuitive.
- Users who deliberately set guild-wide positions in HCL (rare) will see a one-time apparent drift as state converges to sibling-relative numbers; their channels will still sort in the same order if positions are unchanged in Discord.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./discord/ -run TestProvider` passes (schema validates via `InternalValidate`)
- [ ] Acceptance test against a real guild — verified manually: on a guild with ~80 text/forum channels across 7 categories, applying this fix made the previously-permanent 60-channel drift drop to 0 changes on subsequent plans.