### PR TITLE
Fix discord_member_roles import state

### DIFF
--- a/discord/resource_discord_member_roles.go
+++ b/discord/resource_discord_member_roles.go
@@ -30,7 +30,7 @@ func resourceDiscordMemberRoles() *schema.Resource {
 		UpdateContext: resourceMemberRolesUpdate,
 		DeleteContext: resourceMemberRolesDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceMemberRolesImport,
 		},
 
 		Description: "A resource to manage member roles for a server.",
@@ -69,6 +69,18 @@ func resourceDiscordMemberRoles() *schema.Resource {
 			},
 		},
 	}
+}
+
+func resourceMemberRolesImport(ctx context.Context, data *schema.ResourceData, i interface{}) ([]*schema.ResourceData, error) {
+	serverId, userId, err := parseTwoIds(data.Id())
+	if err != nil {
+		return nil, err
+	}
+
+	data.Set("server_id", serverId)
+	data.Set("user_id", userId)
+
+	return schema.ImportStatePassthroughContext(ctx, data, i)
 }
 
 func resourceMemberRolesCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {


### PR DESCRIPTION
This fixes imports for `discord_member_roles`.

Previously, the resource used `schema.ImportStatePassthroughContext`, so importing an ID like:

```text
<server_id>:<user_id>
```

only set the Terraform resource ID. The required `server_id` and `user_id` attributes stayed unset in state, which caused imported resources to be incomplete and produce follow-up diffs/errors.

This PR adds a custom importer that:

- parses the import ID with the existing `parseTwoIds` helper
- sets `server_id`
- sets `user_id`
- then delegates to the passthrough importer

This makes imported `discord_member_roles` resources usable immediately after import.