### PR TITLE
Fix discord_member_roles drift detection: d.Set struct mismatch

### DIFF
--- a/discord/resource_discord_member_roles.go
+++ b/discord/resource_discord_member_roles.go
@@ -23,12 +23,20 @@ func convertToRoleSchema(v interface{}) (*RoleSchema, error) {
 	return roleSchema, err
 }
 
+func roleSchemaToMap(r *RoleSchema) map[string]interface{} {
+	return map[string]interface{}{
+		"role_id":  r.RoleId,
+		"has_role": r.HasRole,
+	}
+}
+
 func resourceDiscordMemberRoles() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceMemberRolesCreate,
 		ReadContext:   resourceMemberRolesRead,
 		UpdateContext: resourceMemberRolesUpdate,
 		DeleteContext: resourceMemberRolesDelete,
+		CustomizeDiff: resourceMemberRolesCustomizeDiff,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -64,8 +72,12 @@ func resourceDiscordMemberRoles() *schema.Resource {
 							Default:     true,
 							Description: "Whether the user should have the role. (default `true`)",
 						},
-					},
-				},
+			"last_updated": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	},
 			},
 		},
 	}
@@ -123,7 +135,13 @@ func resourceMemberRolesRead(ctx context.Context, d *schema.ResourceData, m inte
 			roles = append(roles, &RoleSchema{RoleId: v.RoleId, HasRole: false})
 		}
 	}
-	d.Set("role", roles)
+	roleMaps := make([]interface{}, len(roles))
+	for i, r := range roles {
+		roleMaps[i] = roleSchemaToMap(r)
+	}
+	if err := d.Set("role", roleMaps); err != nil {
+		return diag.Errorf("Failed to set role state: %s", err.Error())
+	}
 
 	return diags
 }
@@ -221,4 +239,30 @@ func resourceMemberRolesDelete(ctx context.Context, d *schema.ResourceData, m in
 	}
 
 	return diags
+}
+
+func resourceMemberRolesCustomizeDiff(ctx context.Context, d *schema.ResourceDiff, m interface{}) error {
+	client := m.(*Context).Session
+
+	serverId := d.Get("server_id").(string)
+	userId := d.Get("user_id").(string)
+
+	member, err := client.GuildMember(serverId, userId, discordgo.WithContext(ctx))
+	if err != nil {
+		// Member not in guild — can't verify. Let normal plan proceed.
+		return nil
+	}
+
+	configRoles := d.Get("role").(*schema.Set).List()
+	for _, r := range configRoles {
+		v, _ := convertToRoleSchema(r)
+		inConfig := v.HasRole
+		inDiscord := hasRole(member, v.RoleId)
+		if inConfig != inDiscord {
+			// Force an update so UpdateContext reconciles the roles
+			return d.ForceNew("role")
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Problem

`discord_member_roles` does not detect when roles are removed from a member on Discord outside of Terraform. `terraform plan` shows no changes and only tainting + reapplying fixes it.

## Root cause

`d.Set("role", roles)` silently fails because `RoleSchema` struct field names (`RoleId`, `HasRole`) do not match Terraform schema keys (`role_id`, `has_role`). Terraform ignores JSON tags when matching keys for `d.Set()`.

## Fix

- Add `roleSchemaToMap()` helper to convert structs to `map[string]interface{}` with schema keys
- Use maps in `d.Set()` during Read
- Check and surface `d.Set` errors
- Add `CustomizeDiff` that reads the Discord API during plan and forces reconciliation when roles differ from config

## Verification

Tested against a live Discord guild:
1. Applied `discord_member_roles` with a role for a member
2. Removed role from the member on Discord
3. `terraform plan` now correctly detects the drift:
   ```
   # module.members.discord_member_roles.<name> will be updated in-place
   ~ resource "discord_member_roles" "<name>" {
       - role {
           - has_role = false -> null
           - role_id  = "912866472190165022" -> null
         }
   ```

Closes #315