### PR TITLE
fix(member): resolve username lookup for migrated (discriminator-less) accounts

### DIFF
--- a/discord/data_source_discord_member.go
+++ b/discord/data_source_discord_member.go
@@ -93,19 +93,14 @@ func dataSourceMemberRead(ctx context.Context, d *schema.ResourceData, m interfa
 
 	if v, ok := d.GetOk("username"); ok {
 		username := v.(string)
-		members, err := client.GuildMembersSearch(serverId, username, 1, discordgo.WithContext(ctx))
+		members, err := client.GuildMembersSearch(serverId, username, 1000, discordgo.WithContext(ctx))
 		if err != nil {
 			return diag.Errorf("Failed to fetch members for %s: %s", serverId, err.Error())
 		}
 
 		discriminator := d.Get("discriminator").(string)
-		memberErr = fmt.Errorf("failed to find member by name#discriminator: %s#%s", username, discriminator)
-		for _, m := range members {
-			if m.User.Username == username && m.User.Discriminator == discriminator {
-				member = m
-				memberErr = nil
-				break
-			}
+		if member = findMemberByUsername(members, username, discriminator); member == nil {
+			memberErr = fmt.Errorf("failed to find member with username %q in server %s", username, serverId)
 		}
 	}
 	if memberErr != nil {
@@ -140,4 +135,21 @@ func dataSourceMemberRead(ctx context.Context, d *schema.ResourceData, m interfa
 	d.Set("nick", member.Nick)
 
 	return diags
+}
+
+// findMemberByUsername returns the first member whose username matches, or nil
+// if none do. The discriminator is only enforced for un-migrated legacy
+// accounts: migrated accounts report a discriminator of "0", while the optional
+// field defaults to "" — neither should block a username match.
+func findMemberByUsername(members []*discordgo.Member, username, discriminator string) *discordgo.Member {
+	for _, m := range members {
+		if m.User.Username != username {
+			continue
+		}
+		if discriminator != "" && discriminator != "0" && m.User.Discriminator != discriminator {
+			continue
+		}
+		return m
+	}
+	return nil
 }

--- a/discord/data_source_discord_member_test.go
+++ b/discord/data_source_discord_member_test.go
@@ -5,8 +5,36 @@ import (
 	"os"
 	"testing"
 
+	"github.com/bwmarrin/discordgo"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
+
+func TestFindMemberByUsername(t *testing.T) {
+	legacy := &discordgo.Member{User: &discordgo.User{Username: "alice", Discriminator: "1234"}}
+	migrated := &discordgo.Member{User: &discordgo.User{Username: "bob", Discriminator: "0"}}
+	members := []*discordgo.Member{legacy, migrated}
+
+	tests := []struct {
+		name          string
+		username      string
+		discriminator string
+		want          *discordgo.Member
+	}{
+		{"migrated account, discriminator omitted", "bob", "", migrated},
+		{"migrated account, discriminator \"0\"", "bob", "0", migrated},
+		{"legacy account, matching discriminator", "alice", "1234", legacy},
+		{"legacy account, discriminator omitted", "alice", "", legacy},
+		{"legacy account, wrong discriminator", "alice", "9999", nil},
+		{"unknown username", "carol", "", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := findMemberByUsername(members, tt.username, tt.discriminator); got != tt.want {
+				t.Errorf("findMemberByUsername(%q, %q) = %v, want %v", tt.username, tt.discriminator, got, tt.want)
+			}
+		})
+	}
+}
 
 func TestAccDatasourceDiscordMember(t *testing.T) {
 	testServerID := os.Getenv("DISCORD_TEST_SERVER_ID")


### PR DESCRIPTION
## Summary

The `discord_member` data source fails to find a member by `username` when the
account has migrated to Discord's new username system (no discriminator).

## The bug

In `dataSourceMemberRead`, the username lookup had two problems:

1. `GuildMembersSearch` was called with a limit of `1`, so only a single
   candidate was ever considered.
2. The match required `m.User.Discriminator == discriminator`. The
   `discriminator` field is optional and defaults to `""`, but migrated
   accounts report a discriminator of `"0"`. Since `"0" != ""`, a lookup by
   username alone never matched a migrated account.

## The fix

- Raise the search limit to `1000` so all candidates are considered.
- Only enforce the discriminator for **legacy** accounts — i.e. when the field
  is set to something other than `""` or `"0"`. Migrated accounts now match on
  username alone.
- Extract the matching logic into a pure `findMemberByUsername` helper so it can
  be unit-tested without hitting the Discord API.

## Testing

- Added `TestFindMemberByUsername`, a table-driven unit test covering:
  migrated account with the discriminator omitted, migrated account with `"0"`,
  legacy account with a matching/omitted/wrong discriminator, and an unknown
  username. Runs in CI under `go test ./...`.
- `go build ./...` and `go test ./...` pass.

No schema or documentation changes (behavior-only fix).